### PR TITLE
chore(internal): added support for UE5.7

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -636,6 +636,21 @@ void FGitSourceControlProvider::UpdateRepositoryStatus(const class FGitSourceCon
 	}
 }
 
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5, 7, 0)
+bool FGitSourceControlProvider::GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const
+{
+	TArray<FString> StatusBranches = GetStatusBranchNames();
+
+	if (BranchIndex >= 0 && BranchIndex < StatusBranches.Num())
+	{
+		OutBranchName = StatusBranches[BranchIndex];
+		return true;
+	}
+
+	return false;
+}
+#endif
+
 void FGitSourceControlProvider::Tick()
 {
 #if ENGINE_MAJOR_VERSION < 5

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -636,7 +636,7 @@ void FGitSourceControlProvider::UpdateRepositoryStatus(const class FGitSourceCon
 	}
 }
 
-#if UE_VERSION_NEWER_THAN_OR_EQUAL(5, 7, 0)
+#if !UE_VERSION_OLDER_THAN(5, 7, 0)
 bool FGitSourceControlProvider::GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const
 {
 	TArray<FString> StatusBranches = GetStatusBranchNames();

--- a/Source/GitSourceControl/Public/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Public/GitSourceControlProvider.h
@@ -9,6 +9,7 @@
 #include "ISourceControlProvider.h"
 #include "IGitSourceControlWorker.h"
 #include "GitSourceControlMenu.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 class FGitSourceControlChangelistState;
@@ -88,6 +89,9 @@ public:
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	virtual bool CanExecuteOperation( const FSourceControlOperationRef& InOperation ) const override;
 	virtual TMap<EStatus, FString> GetStatus() const override;
+#endif
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5, 7, 0)
+	virtual bool GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const override;
 #endif
 	virtual void Tick() override;
 	virtual TArray< TSharedRef<class ISourceControlLabel> > GetLabels( const FString& InMatchingSpec ) const override;

--- a/Source/GitSourceControl/Public/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Public/GitSourceControlProvider.h
@@ -90,7 +90,7 @@ public:
 	virtual bool CanExecuteOperation( const FSourceControlOperationRef& InOperation ) const override;
 	virtual TMap<EStatus, FString> GetStatus() const override;
 #endif
-#if UE_VERSION_NEWER_THAN_OR_EQUAL(5, 7, 0)
+#if !UE_VERSION_OLDER_THAN(5, 7, 0)
 	virtual bool GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const override;
 #endif
 	virtual void Tick() override;


### PR DESCRIPTION
In 5.7 unreal engine added GetStateBranchAtIndex to the ISourceControlProvider interface.
For us to implement the interface, we needed an implementation of this function